### PR TITLE
Change assertion for default branch test after we added git author info to the container

### DIFF
--- a/tests/Integration/DefaultBranchTest.php
+++ b/tests/Integration/DefaultBranchTest.php
@@ -2,6 +2,16 @@
 
 namespace Violinist\UpdateCheckRunner\Tests\Integration;
 
+/**
+ * Test case to test that using a default branch behaves like it should.
+ *
+ * The main purpose of this test is to make sure we are running the outdated and
+ * install commands on the correct branch. For example, if it's overridden to be
+ * set to "develop", and the repo is set to have "main" as its main branch. We
+ * want to make sure we check out the develop branch before we run the commands.
+ * Otherwise the outdated command will be... well, potentially outdated but at
+ * least potentially wrong.
+ */
 class DefaultBranchTest extends IntegrationBase
 {
 
@@ -16,9 +26,20 @@ class DefaultBranchTest extends IntegrationBase
             }
             $found_no_updates = true;
         }
-        // There should for sure be updates. Just on the default branch of the repo, there are none.
+        // And see that we found an update for psr/log. This is an indication
+        // that we ran the outdated command on the config branch, and not on the
+        // main branch.
+        $found_psr_log = false;
+        foreach ($json as $value) {
+            // Check that it contains the psr/log package.
+            if (strpos($value->message, 'psr/log: 1.0.0 installed, ') === false) {
+                continue;
+            }
+            $found_psr_log = true;
+        }
+        self::assertEquals(true, $found_psr_log);
+        // There should for sure be updates. Just on the default branch of the
+        // repo, there are none.
         self::assertEquals(false, $found_no_updates);
-        $this->findMessage('Successfully ran command composer update for package psr/log', $json);
     }
-
 }


### PR DESCRIPTION
This was a test regression introduced after we merged #626 

Basically, after we merged that one, the test was able to also commit and push the files, thus resulting in an actual PR. As a consequence, the assertion in the test went looking for being successful in running the composer update command, but in practice it was skipped since a PR already existed. Earlier it would not exist, since the process would fail with missing git author info