### PR TITLE
Add igbinary to module list for PHP 8.2, 8.3, and 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The following PHP extensions are available in the containers (long table, click 
 | gmp | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | hash | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | iconv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| igbinary | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| igbinary | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | imagick | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | imap | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | intl | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/module-list/8.2.txt
+++ b/module-list/8.2.txt
@@ -20,6 +20,7 @@ gettext
 gmp
 hash
 iconv
+igbinary
 imagick
 imap
 intl

--- a/module-list/8.3.txt
+++ b/module-list/8.3.txt
@@ -20,6 +20,7 @@ gettext
 gmp
 hash
 iconv
+igbinary
 imagick
 imap
 intl

--- a/module-list/8.4.txt
+++ b/module-list/8.4.txt
@@ -20,6 +20,7 @@ gettext
 gmp
 hash
 iconv
+igbinary
 imagick
 imap
 intl


### PR DESCRIPTION
The php-base image now installs igbinary via PIE for these PHP
versions, which made the module-list diff check fail in CI.